### PR TITLE
feat(client) use native command execution instead of qb one

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -39,7 +39,7 @@ for k, v in pairs(availableKeys) do
             if next(keyMeta) ~= nil then
                 if keyMeta[v[2]]["command"] ~= "" then
                     if keyMeta[v[2]]["argument"] ~= "" then args = {[1] = keyMeta[v[2]]["argument"]} else args = {[1] = nil} end
-                    TriggerServerEvent('QBCore:CallCommand', keyMeta[v[2]]["command"], args)
+                    ExecuteCommand(keyMeta[v[2]]["command"] .. " " .. table.concat(args, " "))
                     keyPressed = true
                     Wait(1000)
                     keyPressed = false


### PR DESCRIPTION
**Describe Pull request**
Fix the fact that command binds only work with qbcore commands by using `ExecuteCommand`

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
